### PR TITLE
Allow setting cc_command via $VARNISHD_PARAMS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Przemyslaw Ozgo linux@ozgo.info, Marcin Ryzycki marcin@m12.io
 RUN yum update -y && \
   yum install -y epel-release && \
   yum install -y varnish && \
+  yum install -y libmhash-devel && \
   yum clean all
 
 ADD start.sh /start.sh

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-varnishd -F -u varnish \
+bash -c \
+  "varnishd -F -u varnish \
   -f $VCL_CONFIG \
   -s malloc,$CACHE_SIZE \
-  $VARNISHD_PARAMS
+  $VARNISHD_PARAMS"


### PR DESCRIPTION
With this change people is allowed to set a custom cc_command for varnish (useful if you need some libraries in your C embedded code). This is an example on how to set the parameter in docker-compose.yml:

```
VARNISHD_PARAMS: "-p vcc_allow_inline_c=on -p \"cc_command=exec cc -fpic -shared -Wl,-x -lmhash -o %o %s\""
```

Without this change the opening and closing `"` would be part of the token, not an opener and closer for a multi word token.
